### PR TITLE
Add range_original to DatePeriod class to use range with custom time

### DIFF
--- a/lib/query_filter/utils/date_period.rb
+++ b/lib/query_filter/utils/date_period.rb
@@ -3,7 +3,7 @@
 module QueryFilter
   module Utils
     class DatePeriod
-      attr_reader :date_from, :date_to, :format
+      attr_reader :date_from_raw, :date_to_raw, :format
 
       TIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 
@@ -11,13 +11,30 @@ module QueryFilter
         @format = (format.blank? ? QueryFilter.date_period_format : format)
         @date_from_raw = date_from
         @date_to_raw = date_to
-
-        @date_from = normalize_date(date_from).beginning_of_day
-        @date_to = normalize_date(date_to).end_of_day
       end
 
       def range
         @range ||= date_from..date_to
+      end
+
+      def range_original
+        @range_original ||= date_from_original..date_to_original
+      end
+
+      def date_from
+        @date_from ||= date_from_original.beginning_of_day
+      end
+
+      def date_to
+        @date_to ||= date_to_original.end_of_day
+      end
+
+      def date_from_original
+        @date_from_original ||= normalize_date(@date_from_raw)
+      end
+
+      def date_to_original
+        @date_to_original ||= normalize_date(@date_to_raw)
       end
 
       def title
@@ -25,11 +42,11 @@ module QueryFilter
       end
 
       def datefrom
-        @datefrom ||= I18n.l(@date_from, format: @format)
+        @datefrom ||= I18n.l(date_from, format: @format)
       end
 
       def dateto
-        @dateto ||= I18n.l(@date_to, format: @format)
+        @dateto ||= I18n.l(date_to, format: @format)
       end
 
       def to_param


### PR DESCRIPTION
When we have date with custom time:
```ruby
date_range :range, format: '%m/%d/%Y %H:%M'

def date_range_range(period)
  query.where(created_at: period.range)
end
```

period.range - will ignore time and always return time start_of_day and end_of_day
So new method period.range_original will return dates without time modifications
With fix:
```ruby
def date_range_range(period)
  query.where(created_at: period.range_original)
end
```
  